### PR TITLE
Listen to vue:loaded instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.0|^8.1",
-        "rapidez/core": "^2.0|^3.0",
+        "rapidez/core": "^2.8|^3.0",
         "rapidez/account": ">=0.13.3"
     },
     "autoload": {

--- a/resources/js/eventlisteners.js
+++ b/resources/js/eventlisteners.js
@@ -1,6 +1,6 @@
 import { clear, refresh } from './stores/useAlerts'
 
-document.addEventListener('turbo:load', () => {
+document.addEventListener('vue:loaded', () => {
     window.app.$on('logged-in', refresh);
     window.app.$on('alerts-updated', refresh);
     window.app.$on('logout', clear);


### PR DESCRIPTION
vue:loaded ensures window.app is already available